### PR TITLE
Fix case where dist being built is the dist that contains the share dir

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Revision history for Dist-Zilla-Plugin-GenerateFile-FromShareDir
 
 {{$NEXT}}
+          - When building the a dist that matches the name of the dist which
+            has the share dir, we look in $self->zilla->root for the file
+            rather than in an installed share dir. This fixes an issue where a
+            bundle that uses this plugin cannot be built until the bundle is
+            installed, but you can't install it because you can't build
+            it. Fixed by Dave Rolsky. GitHub #2
 
 0.012     2016-06-22 03:38:43Z
           - declare missing test prereq

--- a/lib/Dist/Zilla/Plugin/GenerateFile/FromShareDir.pm
+++ b/lib/Dist/Zilla/Plugin/GenerateFile/FromShareDir.pm
@@ -111,8 +111,16 @@ sub gather_files
 {
     my $self = shift;
 
-    # this should die if the file does not exist
-    my $file_path = dist_file($self->dist, $self->source_filename);
+    my $file_path;
+    if ($self->dist eq $self->zilla->name)
+    {
+        $file_path = $self->zilla->root->child('share', $self->source_filename);
+    }
+    else
+    {
+        # this should die if the file does not exist
+        $file_path = dist_file($self->dist, $self->source_filename);
+    }
 
     my $content = path($file_path)->slurp_raw;
     $content = Encode::decode($self->encoding, $content, Encode::FB_CROAK());


### PR DESCRIPTION
When building the a dist that matches the name of the dist which has the share
dir, we look in $self->zilla->root for the file rather than in an installed
share dir. This fixes an issue where a bundle that uses this plugin cannot be
built until the bundle is installed, but you can't install it because you
can't build it.